### PR TITLE
Android Audio Focus Not Acquired

### DIFF
--- a/constants/AudioManager.js
+++ b/constants/AudioManager.js
@@ -45,10 +45,12 @@ class AudioManager {
     try {
       await soundObject.playFromPositionAsync(0);
     } catch (error) {
-      Sentry.withScope(function(scope) {
-        Sentry.setContext("sound", {"name": name, "soundType": soundType});
-        Sentry.captureException(error);
-      });
+      if (error.name !== "AudioFocusNotAcquiredException") {
+        Sentry.withScope(function(scope) {
+          Sentry.setContext("sound", {"name": name, "soundType": soundType});
+          Sentry.captureException(error);
+        });
+      }
     }
   };
 


### PR DESCRIPTION
### Reference Issue

<!-- Link to the GitHub Issue -->
https://github.com/RomzaLabs/KnitCount2/issues/162

### Description

<!-- A brief description of what is changing and why. -->
Silencing Sentry logs if Android Focus is not acquired.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)


### Changes
<!-- Checklist of proposed changes. To mark a change as complete, put an 'x' in the box. -->
- [x] Don't record Sentry logs if Android Audio Focus is not acquired.


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Review
<!-- Checklist of peers to review and test the code. Recommend including a due date. -->
N/A

